### PR TITLE
Add project README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# Barbería Q2N
+
+Aplicación React para gestión de turnos que utiliza Firebase para la autenticación y la base de datos. Incluye funciones en Cloud Functions para tareas programadas y se puede publicar en GitHub Pages.
+
+## Requisitos
+
+- [Node.js](https://nodejs.org/) 18 o superior.
+- [Firebase CLI](https://firebase.google.com/docs/cli) (`npm install -g firebase-tools`).
+
+## Instalación de dependencias
+
+En la raíz del proyecto instala las dependencias del cliente:
+
+```bash
+npm install
+```
+
+Para las funciones de Firebase ejecuta:
+
+```bash
+cd functions && npm install && cd ..
+```
+
+## Configuración de variables de entorno
+
+Crea un archivo `.env` en la raíz con tus valores de Firebase y los identificadores propios de la aplicación:
+
+```dotenv
+VITE_PROJECT_NAME=Mi Barberia
+VITE_COMPANY_ID=tu_compania
+VITE_FIREBASE_API_KEY=XXXX
+VITE_FIREBASE_AUTH_DOMAIN=XXXX
+VITE_FIREBASE_PROJECT_ID=XXXX
+VITE_FIREBASE_STORAGE_BUCKET=XXXX
+VITE_FIREBASE_MESSAGING_SENDER_ID=XXXX
+VITE_FIREBASE_APP_ID=XXXX
+```
+
+Si usas las funciones de envío de correos configura SendGrid:
+
+```bash
+firebase functions:config:set sendgrid.key="TU_SENDGRID_API_KEY"
+```
+
+## Entorno de desarrollo
+
+Inicia Vite con:
+
+```bash
+npm start
+```
+
+El servidor quedará disponible normalmente en `http://localhost:5173`.
+
+## Despliegue
+
+### GitHub Pages
+
+Ejecuta:
+
+```bash
+npm run deploy
+```
+
+Se compilará la aplicación y se publicará el contenido de `dist/` en la rama `gh-pages`.
+
+### Firebase
+
+Para desplegar las Cloud Functions (y Hosting si lo configuras) usa:
+
+```bash
+firebase deploy
+```
+


### PR DESCRIPTION
## Summary
- add `README.md` with prerequisites, environment configuration, development and deployment steps

## Testing
- `npm test` *(fails: No tests found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ee2f5cb908327bfacc18f66842c83