### PR TITLE
Filter past appointments in MyAppointmentsScreen

### DIFF
--- a/src/components/MyAppointmentsScreen.jsx
+++ b/src/components/MyAppointmentsScreen.jsx
@@ -26,7 +26,10 @@ export default function MyAppointmentsScreen() {
         where('clientId', '==', auth.currentUser.uid)
       );
       const snap = await getDocs(q);
-      const data = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+      const now = new Date();
+      const data = snap.docs
+        .map(d => ({ id: d.id, ...d.data() }))
+        .filter(a => new Date(a.datetime) >= now);
       data.sort((a, b) => new Date(a.datetime) - new Date(b.datetime));
       setAppointments(data);
       setLoading(false);


### PR DESCRIPTION
## Summary
- filter appointments in MyAppointmentsScreen so only upcoming appointments appear

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_686f1085089c8327b0481e9e429e8b24