### PR TITLE
Add user profile edit screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import ServiceSummaryScreen from './components/ServiceSummaryScreen';
 import StylistSelectionScreen from './components/StylistSelectionScreen';
 import ProfessionalCalendarScreen from './components/ProfessionalCalendarScreen';
 import MyAppointmentsScreen from './components/MyAppointmentsScreen';
+import MyProfileScreen from './components/MyProfileScreen';
 import AdminRouter from './routes/AdminRouter';
 import Login from './components/Login';
 
@@ -53,6 +54,7 @@ function AppContent() {
           {user && (
             <>
               <Link to="/mis-turnos" className={baseBtn}>Mis Turnos</Link>
+              <Link to="/mi-perfil" className={baseBtn}>Mi Perfil</Link>
               {isTenantAdmin && (
                 <Link to="/admin" className={baseBtn}>Panel Admin</Link>
               )}
@@ -98,6 +100,15 @@ function AppContent() {
             element={
               <RequireAuth>
                 <MyAppointmentsScreen />
+              </RequireAuth>
+            }
+          />
+
+          <Route
+            path="/mi-perfil"
+            element={
+              <RequireAuth>
+                <MyProfileScreen />
               </RequireAuth>
             }
           />

--- a/src/components/MyProfileScreen.jsx
+++ b/src/components/MyProfileScreen.jsx
@@ -1,0 +1,71 @@
+import React, { useState, useEffect } from 'react';
+import { doc, updateDoc } from 'firebase/firestore';
+import { db } from '../firebaseConfig';
+import { useAuth } from '../AuthProvider';
+
+export default function MyProfileScreen() {
+  const { user, profile } = useAuth();
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [phone, setPhone] = useState('');
+
+  useEffect(() => {
+    if (profile) {
+      setFirstName(profile.firstName || '');
+      setLastName(profile.lastName || '');
+      setPhone(profile.phone || '');
+    }
+  }, [profile]);
+
+  const handleSave = async () => {
+    if (!firstName.trim() || !lastName.trim()) {
+      alert('Completa nombre y apellido');
+      return;
+    }
+    try {
+      await updateDoc(doc(db, 'users', user.uid), {
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        phone: phone.trim(),
+      });
+      alert('Datos actualizados');
+    } catch (err) {
+      alert('Error al guardar');
+    }
+  };
+
+  if (!user) return null;
+
+  return (
+    <div className="p-4 max-w-sm mx-auto space-y-4">
+      <h2 className="text-2xl font-bold text-center">Mi Perfil</h2>
+      <input
+        type="text"
+        placeholder="Nombre"
+        value={firstName}
+        onChange={e => setFirstName(e.target.value)}
+        className="border p-2 w-full rounded"
+      />
+      <input
+        type="text"
+        placeholder="Apellido"
+        value={lastName}
+        onChange={e => setLastName(e.target.value)}
+        className="border p-2 w-full rounded"
+      />
+      <input
+        type="tel"
+        placeholder="Teléfono"
+        value={phone}
+        onChange={e => setPhone(e.target.value)}
+        className="border p-2 w-full rounded"
+      />
+      <button
+        onClick={handleSave}
+        className="w-full bg-blue-500 text-white py-2 rounded-full hover:bg-blue-600 transition"
+      >
+        Guardar Cambios
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `MyProfileScreen` component for editing name and phone
- link to new profile screen from header navigation
- route `/mi-perfil` to the new screen

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686f232cb6508327ae6699dec34a2b13