### PR TITLE
Add phone split fields in profile edit

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -7,13 +7,7 @@ import {
 } from 'firebase/auth';
 import { auth, db } from '../firebaseConfig';
 import { doc, setDoc } from 'firebase/firestore';
-
-const COUNTRY_CODES = [
-  { code: '+54', label: '' },
-];
-const AREA_CODES = [
-  { code: '2262', label: 'Necochea' },
-];
+import { COUNTRY_CODES, AREA_CODES } from '../data/phone';
 
 export default function Login() {
   const navigate = useNavigate();

--- a/src/data/phone.js
+++ b/src/data/phone.js
@@ -1,0 +1,7 @@
+export const COUNTRY_CODES = [
+  { code: '+54', label: '' },
+];
+
+export const AREA_CODES = [
+  { code: '2262', label: 'Necochea' },
+];


### PR DESCRIPTION
## Summary
- centralize phone constants
- use phone code and area fields on profile screen
- refactor login to use shared phone constants

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686f261f7c00832785ece0d3265db2d3