### PR TITLE
Dynamic tenant data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ cd functions && npm install && cd ..
 
 ## Configuración de variables de entorno
 
-Crea un archivo `.env` en la raíz con tus valores de Firebase y los identificadores propios de la aplicación:
+Crea un archivo `.env` en la raíz con tus valores de Firebase:
 
 ```dotenv
-VITE_PROJECT_NAME=Mi Barberia
-VITE_COMPANY_ID=tu_compania
 VITE_FIREBASE_API_KEY=XXXX
 VITE_FIREBASE_AUTH_DOMAIN=XXXX
 VITE_FIREBASE_PROJECT_ID=XXXX
@@ -35,6 +33,18 @@ VITE_FIREBASE_STORAGE_BUCKET=XXXX
 VITE_FIREBASE_MESSAGING_SENDER_ID=XXXX
 VITE_FIREBASE_APP_ID=XXXX
 ```
+
+### Configuración de clientes (tenants)
+
+Crea una colección `tenants` en Firestore donde cada documento represente un cliente. El ID del documento será el *slug* utilizado en la URL y debe incluir al menos los campos `companyId` y `projectName`:
+
+```text
+tenants/
+  barberia1 { companyId: "c1", projectName: "Barbería 1" }
+  barberia2 { companyId: "c2", projectName: "Barbería 2" }
+```
+
+Al acceder a `agendarturnos.ar/{cliente}` la aplicación cargará estos datos y los usará para filtrar la información.
 
 Si usas las funciones de envío de correos configura SendGrid:
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import {
 import { signOut } from 'firebase/auth';
 import { auth } from './firebaseConfig';
 import { AuthProvider, useAuth } from './AuthProvider';
+import { TenantProvider, useTenant } from './TenantProvider';
 import RequireAuth from './components/RequireAuth';
 import PasswordReset from './components/PasswordReset';
 import ServiceListScreen from './components/ServiceListScreen';
@@ -22,15 +23,21 @@ import MyProfileScreen from './components/MyProfileScreen';
 import AdminRouter from './routes/AdminRouter';
 import Login from './components/Login';
 
-const projectName = String(import.meta.env.VITE_PROJECT_NAME || 'Mi Aplicación');
-const COMPANY_ID  = import.meta.env.VITE_COMPANY_ID;
-
 export default function App() {
   return (
     <AuthProvider>
-     <Router basename="/q2nbarberia">
-
-        <AppContent />
+      <Router>
+        <Routes>
+          <Route
+            path="/:tenant/*"
+            element={
+              <TenantProvider>
+                <AppContent />
+              </TenantProvider>
+            }
+          />
+          <Route path="*" element={<Navigate to="/demo" replace />} />
+        </Routes>
       </Router>
     </AuthProvider>
   );
@@ -39,9 +46,10 @@ export default function App() {
 function AppContent() {
   const { user, profile } = useAuth();
   const location         = useLocation();
+  const { slug, projectName, companyId } = useTenant();
   // usados para mostrar/ocultar el panel admin
   const isTenantAdmin    =
-    profile?.isAdmin === true && profile?.companyId === COMPANY_ID;
+    profile?.isAdmin === true && profile?.companyId === companyId;
 
   const baseBtn =
     "px-3 py-1 rounded-full text-sm font-medium bg-white text-gray-800 border border-gray-300 hover:bg-gray-50 transition";
@@ -49,14 +57,14 @@ function AppContent() {
   return (
     <>
       <header className="p-4 bg-gray-100 flex flex-wrap justify-between items-center gap-2">
-        <Link to="/" className="text-xl font-bold">{projectName}</Link>
+        <Link to={`/${slug}`} className="text-xl font-bold">{projectName}</Link>
         <div className="flex flex-wrap items-center gap-2">
           {user && (
             <>
-              <Link to="/mis-turnos" className={baseBtn}>Mis Turnos</Link>
-              <Link to="/mi-perfil" className={baseBtn}>Mi Perfil</Link>
+              <Link to={`/${slug}/mis-turnos`} className={baseBtn}>Mis Turnos</Link>
+              <Link to={`/${slug}/mi-perfil`} className={baseBtn}>Mi Perfil</Link>
               {isTenantAdmin && (
-                <Link to="/admin" className={baseBtn}>Panel Admin</Link>
+                <Link to={`/${slug}/admin`} className={baseBtn}>Panel Admin</Link>
               )}
             </>
           )}
@@ -68,26 +76,26 @@ function AppContent() {
               Logout
             </button>
           ) : (
-            <Link to="/login" className={baseBtn}>Login</Link>
+            <Link to={`/${slug}/login`} className={baseBtn}>Login</Link>
           )}
         </div>
       </header>
 
       <main className="p-4">
         <Routes>
-          <Route path="/" element={<ServiceListScreen />} />
-          <Route path="/summary" element={<ServiceSummaryScreen />} />
-          <Route path="/stylists" element={<StylistSelectionScreen />} />
+          <Route index element={<ServiceListScreen />} />
+          <Route path="summary" element={<ServiceSummaryScreen />} />
+          <Route path="stylists" element={<StylistSelectionScreen />} />
 
           <Route
-            path="/login"
-            element={user ? <Navigate to="/" replace /> : <Login />}
+            path="login"
+            element={user ? <Navigate to="" replace /> : <Login />}
           />
 
-          <Route path="/reset-password" element={<PasswordReset />} />
+          <Route path="reset-password" element={<PasswordReset />} />
 
           <Route
-            path="/professional"
+            path="professional"
             element={
               <RequireAuth>
                 <ProfessionalCalendarScreen />
@@ -96,7 +104,7 @@ function AppContent() {
           />
 
           <Route
-            path="/mis-turnos"
+            path="mis-turnos"
             element={
               <RequireAuth>
                 <MyAppointmentsScreen />
@@ -105,7 +113,7 @@ function AppContent() {
           />
 
           <Route
-            path="/mi-perfil"
+            path="mi-perfil"
             element={
               <RequireAuth>
                 <MyProfileScreen />
@@ -114,19 +122,19 @@ function AppContent() {
           />
 
           <Route
-            path="/admin/*"
+            path="admin/*"
             element={
               <RequireAuth>
                 {isTenantAdmin ? (
                   <AdminRouter />
                 ) : (
-                  <Navigate to="/" replace />
+                  <Navigate to="" replace />
                 )}
               </RequireAuth>
             }
           />
 
-          <Route path="*" element={<Navigate to="/" replace />} />
+          <Route path="*" element={<Navigate to="" replace />} />
         </Routes>
       </main>
     </>

--- a/src/TenantProvider.jsx
+++ b/src/TenantProvider.jsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from './firebaseConfig';
+
+const TenantContext = createContext(null);
+
+export function useTenant() {
+  return useContext(TenantContext);
+}
+
+export function TenantProvider({ children }) {
+  const { tenant } = useParams();
+  const [config, setConfig] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchTenant() {
+      try {
+        const snap = await getDoc(doc(db, 'tenants', tenant));
+        setConfig(snap.exists() ? { slug: tenant, ...snap.data() } : null);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchTenant();
+  }, [tenant]);
+
+  if (loading) return <p className="p-4 text-center">Cargando...</p>;
+  if (!config) return <p className="p-4 text-center">Cliente no válido</p>;
+
+  return (
+    <TenantContext.Provider value={config}>{children}</TenantContext.Provider>
+  );
+}

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,6 +1,7 @@
 // src/components/Login.jsx
 import React, { useState } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useTenant } from '../TenantProvider';
 import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword
@@ -12,7 +13,8 @@ import { COUNTRY_CODES, AREA_CODES } from '../data/phone';
 export default function Login() {
   const navigate = useNavigate();
   const location = useLocation();
-  const from = location.state?.from?.pathname || '/';
+  const { slug } = useTenant();
+  const from = location.state?.from?.pathname || `/${slug}`;
   const fromState = location.state?.from?.state || {};
 
   const [email,     setEmail    ] = useState('');
@@ -145,7 +147,7 @@ export default function Login() {
         >
           {isRegister ? 'Ya tengo cuenta' : 'Crear cuenta'}
         </button>
-         <Link to="/reset-password" className="text-blue-500 underline">
+         <Link to={`/${slug}/reset-password`} className="text-blue-500 underline">
            Recuperar Contraseña
          </Link>
       </div>

--- a/src/components/PasswordReset.jsx
+++ b/src/components/PasswordReset.jsx
@@ -3,11 +3,13 @@ import React, { useState } from 'react';
 import { sendPasswordResetEmail } from 'firebase/auth';
 import { auth } from '../firebaseConfig';
 import { Link } from 'react-router-dom';
+import { useTenant } from '../TenantProvider';
 
 export default function PasswordReset() {
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState({ type: '', message: '' });
   const [loading, setLoading] = useState(false);
+  const { slug } = useTenant();
 
   const handleReset = async e => {
     e.preventDefault();
@@ -69,7 +71,7 @@ export default function PasswordReset() {
         </button>
       </form>
       <div className="text-center text-sm">
-        <Link to="/login" className="text-blue-500 underline">
+        <Link to={`/${slug}/login`} className="text-blue-500 underline">
           Volver al login
         </Link>
       </div>

--- a/src/components/ProfessionalCalendarScreen.jsx
+++ b/src/components/ProfessionalCalendarScreen.jsx
@@ -13,12 +13,13 @@ import {
   isBefore,
 } from 'date-fns';
 import { es } from 'date-fns/locale';
-const COMPANY_ID  = import.meta.env.VITE_COMPANY_ID;
+import { useTenant } from '../TenantProvider';
 
 export default function ProfessionalCalendarScreen() {
   const navigate = useNavigate();
   const { state } = useLocation();
   const { stylist, service, from, datetime } = state || {};
+  const { companyId, slug } = useTenant();
 
   const [appointments, setAppointments] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -34,7 +35,7 @@ export default function ProfessionalCalendarScreen() {
   // Cargar citas existentes
   useEffect(() => {
     if (!stylist || !service) {
-      navigate('/', { replace: true });
+      navigate(`/${slug}`, { replace: true });
       return;
     }
     getDocs(collection(db, 'appointments'))
@@ -139,7 +140,7 @@ export default function ProfessionalCalendarScreen() {
   const handleSlotClick = useCallback(
     async dt => {
       if (!auth.currentUser) {
-        navigate('/login', {
+        navigate(`/${slug}/login`, {
           state: {
             from: 'booking',
             stylist,
@@ -167,10 +168,10 @@ export default function ProfessionalCalendarScreen() {
           clientEmail: auth.currentUser.email,
           datetime: dt.toISOString(),
           duration: service.duration,
-          companyId: COMPANY_ID,
+          companyId: companyId,
         });
         alert('Turno reservado correctamente.');
-        navigate('/');
+        navigate(`/${slug}`);
       } catch (error) {
         console.error('Error guardando turno:', error);
         alert('Ocurrió un error al reservar el turno. Intenta nuevamente.');

--- a/src/components/RequireAuth.jsx
+++ b/src/components/RequireAuth.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { auth } from '../firebaseConfig';
+import { useTenant } from '../TenantProvider';
 
 export default function RequireAuth({ children }) {
   const location = useLocation();
+  const { slug } = useTenant();
   if (!auth.currentUser) {
     // guardamos la ruta completa (pathname + state) en from
-    return <Navigate to="/login" state={{ from: location }} replace />;
+    return <Navigate to={`/${slug}/login`} state={{ from: location }} replace />;
   }
   return children;
 }

--- a/src/components/ServiceListScreen.jsx
+++ b/src/components/ServiceListScreen.jsx
@@ -3,22 +3,20 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { collection, getDocs, query, where } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
-
-const COMPANY_ID = import.meta.env.VITE_COMPANY_ID;
+import { useTenant } from '../TenantProvider';
 
 export default function ServiceListScreen() {
+  const { companyId, slug } = useTenant();
   const [services, setServices] = useState([]);
   const [categories, setCategories] = useState([]);
   const [selectedCat, setSelectedCat] = useState('');
 
-  // Nombre del proyecto (opcional)
-  const projectName = import.meta.env.VITE_PROJECT_NAME || 'Servicios';
 
   useEffect(() => {
     async function fetchServices() {
       const q = query(
         collection(db, 'services'),
-        where('companyId', '==', COMPANY_ID)
+        where('companyId', '==', companyId)
       );
       const snap = await getDocs(q);
       setServices(snap.docs.map(d => ({ id: d.id, ...d.data() })));
@@ -30,7 +28,7 @@ export default function ServiceListScreen() {
     async function fetchCategories() {
       const q = query(
         collection(db, 'categories'),
-        where('companyId', '==', COMPANY_ID)
+        where('companyId', '==', companyId)
       );
       const snap = await getDocs(q);
       setCategories(snap.docs.map(d => ({ id: d.id, ...d.data() })));
@@ -91,7 +89,7 @@ export default function ServiceListScreen() {
               Duración: {svc.duration} min
             </p>
             <Link
-              to="/summary"
+              to={`/${slug}/summary`}
               state={{ service: svc }}
               className="mt-auto w-full py-2 border border-blue-500 text-blue-500 rounded-full text-center hover:bg-blue-500 hover:text-white transition"
             >

--- a/src/components/ServiceSummaryScreen.jsx
+++ b/src/components/ServiceSummaryScreen.jsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useTenant } from '../TenantProvider';
 
 export default function ServiceSummaryScreen() {
   const navigate = useNavigate();
   const { state } = useLocation();
   const service = state?.service;
+  const { slug } = useTenant();
 
   if (!service) {
     return (
       <div className="p-4 text-center">
         <p className="text-gray-500 mb-4">No se encontró el servicio seleccionado.</p>
         <button
-          onClick={() => navigate('/')}
+          onClick={() => navigate(`/${slug}`)}
           className="text-blue-500 underline"
         >
           Volver al menú
@@ -29,7 +31,7 @@ export default function ServiceSummaryScreen() {
         <p className="text-gray-600 mb-2">Seña: ${service.senia}</p>
         <p className="text-gray-600 mb-6">Duración: {service.duration} min</p>
         <button
-          onClick={() => navigate('/stylists', { state: { service } })}
+          onClick={() => navigate(`/${slug}/stylists`, { state: { service } })}
           className="mt-auto w-full py-2 border border-blue-500 text-blue-500 rounded-full hover:bg-blue-500 hover:text-white transition"
         >
           Elegir Profesional

--- a/src/components/StylistSelectionScreen.jsx
+++ b/src/components/StylistSelectionScreen.jsx
@@ -2,16 +2,18 @@ import React, { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { collection, getDocs } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
+import { useTenant } from '../TenantProvider';
 
 export default function StylistSelectionScreen() {
   const navigate = useNavigate();
   const { state } = useLocation();
   const service = state?.service;
+  const { slug } = useTenant();
 
   // Si no hay servicio, volvemos al listado
   useEffect(() => {
     if (!service) {
-      navigate('/', { replace: true });
+      navigate(`/${slug}`, { replace: true });
     }
   }, [service, navigate]);
 
@@ -59,7 +61,7 @@ export default function StylistSelectionScreen() {
               </div>
               <button
                 onClick={() =>
-                  navigate('/professional', { state: { service, stylist: st } })
+                  navigate(`/${slug}/professional`, { state: { service, stylist: st } })
                 }
                 className="py-2 px-4 border border-blue-500 text-blue-500 rounded-full hover:bg-blue-500 hover:text-white transition"
               >

--- a/src/routes/AdminRouter.jsx
+++ b/src/routes/AdminRouter.jsx
@@ -12,10 +12,10 @@ import {
   onSnapshot
 } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
-
-const COMPANY_ID = import.meta.env.VITE_COMPANY_ID;
+import { useTenant } from '../TenantProvider';
 
 export default function AdminRouter() {
+  const { companyId } = useTenant();
   const [services, setServices]       = useState([]);
   const [stylists, setStylists]       = useState([]);
   const [appointments, setAppointments] = useState([]);
@@ -25,7 +25,7 @@ export default function AdminRouter() {
     // Query compartido: todos filtrados por companyId
     const qServices = query(
       collection(db, 'services'),
-      where('companyId', '==', COMPANY_ID)
+      where('companyId', '==', companyId)
     );
     const unsubServices = onSnapshot(qServices, snap =>
       setServices(snap.docs.map(d => ({ id: d.id, ...d.data() })))
@@ -33,7 +33,7 @@ export default function AdminRouter() {
 
     const qStylists = query(
       collection(db, 'stylists'),
-      where('companyId', '==', COMPANY_ID)
+      where('companyId', '==', companyId)
     );
     const unsubStylists = onSnapshot(qStylists, snap =>
       setStylists(snap.docs.map(d => ({ id: d.id, ...d.data() })))
@@ -41,7 +41,7 @@ export default function AdminRouter() {
 
     const qAppointments = query(
       collection(db, 'appointments'),
-      where('companyId', '==', COMPANY_ID)
+      where('companyId', '==', companyId)
     );
     const unsubAppointments = onSnapshot(qAppointments, snap => {
       const today = new Date();
@@ -55,7 +55,7 @@ export default function AdminRouter() {
 
     const qCategories = query(
       collection(db, 'categories'),
-      where('companyId', '==', COMPANY_ID)
+      where('companyId', '==', companyId)
     );
     const unsubCategories = onSnapshot(qCategories, snap =>
       setCategories(snap.docs.map(d => ({ id: d.id, ...d.data() })))
@@ -73,13 +73,13 @@ export default function AdminRouter() {
   const handleAddService = async data => {
     await addDoc(collection(db, 'services'), {
       ...data,
-      companyId: COMPANY_ID
+      companyId: companyId
     });
   };
   const handleUpdateService = async (id, data) => {
     await updateDoc(doc(db, 'services', id), {
       ...data,
-      companyId: COMPANY_ID
+      companyId: companyId
     });
   };
   const handleDeleteService = async id => {
@@ -89,13 +89,13 @@ export default function AdminRouter() {
   const handleAddProfessional = async data => {
     await addDoc(collection(db, 'stylists'), {
       ...data,
-      companyId: COMPANY_ID
+      companyId: companyId
     });
   };
   const handleUpdateProfessional = async (id, data) => {
     await updateDoc(doc(db, 'stylists', id), {
       ...data,
-      companyId: COMPANY_ID
+      companyId: companyId
     });
   };
   const handleDeleteProfessional = async id => {
@@ -105,13 +105,13 @@ export default function AdminRouter() {
   const handleAddCategory = async data => {
     await addDoc(collection(db, 'categories'), {
       ...data,
-      companyId: COMPANY_ID
+      companyId: companyId
     });
   };
   const handleUpdateCategory = async (id, data) => {
     await updateDoc(doc(db, 'categories', id), {
       ...data,
-      companyId: COMPANY_ID
+      companyId: companyId
     });
   };
   const handleDeleteCategory = async id => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: '/q2nbarberia/',
+  base: '/',
   plugins: [react()],
     define: {
     'process.env.VITE_PROJECT_NAME': JSON.stringify(process.env.VITE_PROJECT_NAME)


### PR DESCRIPTION
## Summary
- load client configuration from Firestore via new `TenantProvider`
- route all pages under `/:tenant` and use the tenant data in components
- update all navigation links to include the tenant slug
- document multi-tenant setup in README
- set Vite base path to `/`

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6872ecd039108327a85fa33c0df7fcb5