### PR TITLE
Add tenant-based deposit confirmation logic

### DIFF
--- a/src/components/AdminAppointmentsScreen.jsx
+++ b/src/components/AdminAppointmentsScreen.jsx
@@ -10,10 +10,12 @@ import {
   doc
 } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
+import { useTenant } from '../TenantProvider';
 
 export default function AdminAppointmentsScreen({ appointments }) {
   const [selectedDate, setSelectedDate] = useState(null);
   const [users, setUsers] = useState([]);
+  const { usaConfirmacionSenia } = useTenant() || {};
 
   useEffect(() => {
     const unsub = onSnapshot(collection(db, 'users'), snap =>
@@ -79,7 +81,9 @@ export default function AdminAppointmentsScreen({ appointments }) {
                 <th className="px-4 py-2 text-left">Servicio</th>
                 <th className="px-4 py-2 text-left">Cliente</th>
                 <th className="px-4 py-2 text-left">Teléfono</th>
-                <th className="px-4 py-2 text-left">Seña</th>
+                {usaConfirmacionSenia && (
+                  <th className="px-4 py-2 text-left">Seña</th>
+                )}
                 <th className="px-4 py-2 text-center">Acciones</th>
               </tr>
             </thead>
@@ -121,13 +125,15 @@ export default function AdminAppointmentsScreen({ appointments }) {
                         '—'
                       )}
                     </td>
-                    <td className="px-4 py-2">
-                      {appt.depositConfirmed
-                        ? <span className="text-green-600">Confirmada</span>
-                        : <span className="text-red-600">Pendiente</span>}
-                    </td>
+                    {usaConfirmacionSenia && (
+                      <td className="px-4 py-2">
+                        {appt.depositConfirmed
+                          ? <span className="text-green-600">Confirmada</span>
+                          : <span className="text-red-600">Pendiente</span>}
+                      </td>
+                    )}
                     <td className="px-4 py-2 text-center space-x-2">
-                      {!appt.depositConfirmed && (
+                      {usaConfirmacionSenia && !appt.depositConfirmed && (
                         <button
                           onClick={() => handleConfirmDeposit(appt)}
                           className="px-2 py-1 bg-yellow-500 text-white rounded text-xs hover:bg-yellow-600 transition"
@@ -162,7 +168,7 @@ export default function AdminAppointmentsScreen({ appointments }) {
                 <div className="flex justify-between">
                   <span className="font-semibold">{format(dt, 'HH:mm')}</span>
                   <div className="flex space-x-2">
-                    {!appt.depositConfirmed && (
+                    {usaConfirmacionSenia && !appt.depositConfirmed && (
                       <button
                         onClick={() => handleConfirmDeposit(appt)}
                         className="bg-yellow-500 text-white px-2 py-1 rounded-full text-xs hover:bg-yellow-600 transition"
@@ -206,12 +212,14 @@ export default function AdminAppointmentsScreen({ appointments }) {
                     <span>—</span>
                   )}
                 </p>
-                <p className="text-sm">
-                  <strong>Seña:</strong>{' '}
-                  {appt.depositConfirmed
-                    ? <span className="text-green-600">Confirmada</span>
-                    : <span className="text-red-600">Pendiente</span>}
-                </p>
+                {usaConfirmacionSenia && (
+                  <p className="text-sm">
+                    <strong>Seña:</strong>{' '}
+                    {appt.depositConfirmed
+                      ? <span className="text-green-600">Confirmada</span>
+                      : <span className="text-red-600">Pendiente</span>}
+                  </p>
+                )}
               </div>
             );
           })}

--- a/src/components/MyAppointmentsScreen.jsx
+++ b/src/components/MyAppointmentsScreen.jsx
@@ -11,12 +11,14 @@ import {
 import { format, parseISO } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { db, auth } from '../firebaseConfig';
+import { useTenant } from '../TenantProvider';
 
 export default function MyAppointmentsScreen() {
   const [appointments, setAppointments] = useState([]);
   const [stylists, setStylists] = useState([]);
   const [services, setServices] = useState([]);
   const [loading, setLoading] = useState(true);
+  const { usaConfirmacionSenia } = useTenant() || {};
 
   // Fetch my appointments
   useEffect(() => {
@@ -150,14 +152,14 @@ export default function MyAppointmentsScreen() {
                   <p className="text-gray-600 text-sm">Con {a.stylistName}</p>
 
                   {/* Valor de la seña (tomado del servicio) */}
-                  {depositValue != null && (
+                  {usaConfirmacionSenia && depositValue != null && (
                     <p className="text-gray-700 text-sm">
                       Valor de la seña: ${depositValue}
                     </p>
                   )}
 
                   {/* Alias de pago */}
-                  {stylistAlias && (
+                  {usaConfirmacionSenia && stylistAlias && (
                     <div className="flex items-center text-sm text-gray-700">
                       <span>Alias de pago: {stylistAlias}</span>
                       <button
@@ -184,17 +186,19 @@ export default function MyAppointmentsScreen() {
                     {format(apptDate, "PPP 'a las' p", { locale: es })}
                   </p>
 
-                  <div className="flex space-x-2">
-                    <span
-                      className={`inline-block px-2 py-1 rounded-full text-xs font-medium ${
-                        depositConfirmed
-                          ? 'bg-green-100 text-green-800'
-                          : 'bg-yellow-100 text-yellow-800'
-                      }`}
-                    >
-                      Seña {depositConfirmed ? 'Confirmada' : 'Pendiente'}
-                    </span>
-                  </div>
+                  {usaConfirmacionSenia && (
+                    <div className="flex space-x-2">
+                      <span
+                        className={`inline-block px-2 py-1 rounded-full text-xs font-medium ${
+                          depositConfirmed
+                            ? 'bg-green-100 text-green-800'
+                            : 'bg-yellow-100 text-yellow-800'
+                        }`}
+                      >
+                        Seña {depositConfirmed ? 'Confirmada' : 'Pendiente'}
+                      </span>
+                    </div>
+                  )}
                 </div>
 
                 <div className="mt-3 sm:mt-0 flex flex-col sm:flex-row sm:items-center sm:space-x-2">


### PR DESCRIPTION
## Summary
- respect `usaConfirmacionSenia` flag in tenant configuration
- hide deposit information and controls when the tenant doesn't use deposits

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68733273d34c8327a7490cfe50ad004d